### PR TITLE
Amends HOSTFILE to include ".conf" extension

### DIFF
--- a/lamp-vhost-manager.sh
+++ b/lamp-vhost-manager.sh
@@ -409,7 +409,7 @@ else
 fi
 
 # Virtual host file
-VHOSTFILE="/etc/apache2/sites-available/$NAME"
+VHOSTFILE="/etc/apache2/sites-available/$NAME.conf"
 
 # Virtual host document root
 VHOSTDOCROOT="$DOCROOT/$NAME"


### PR DESCRIPTION
The lack of a conf extension prevents a2ensite from creating a link in sites-enabled
